### PR TITLE
Validar cédula dominicana con algoritmo Luhn

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third-party notices
+
+## OGTIC Cuenta Única Registry
+
+The Dominican identity-card checksum validation in LoanCalc RD was adapted from the public repository **ogticrd/cuenta-unica-registry**.
+
+- Source: https://github.com/ogticrd/cuenta-unica-registry
+- Copyright © 2023 Oficina Gubernamental de Tecnologías de la Información y Comunicación (OGTIC)
+- License: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files, to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, subject to inclusion of the copyright and permission notice.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.

--- a/calculadora-prestamos/src/app/core/validators/dominican-id.validator.ts
+++ b/calculadora-prestamos/src/app/core/validators/dominican-id.validator.ts
@@ -1,0 +1,36 @@
+/**
+ * Validates Dominican identity-card numbers using the Luhn checksum.
+ *
+ * Adapted from the public OGTIC Cuenta Única Registry implementation:
+ * https://github.com/ogticrd/cuenta-unica-registry
+ * License: MIT.
+ */
+export function isValidDominicanId(value: string): boolean {
+  const digits = value.replace(/\D/g, '');
+
+  if (!/^\d{11}$/.test(digits)) {
+    return false;
+  }
+
+  const reversedDigits = digits
+    .split('')
+    .reverse()
+    .map(Number);
+
+  const verificationDigit = reversedDigits.shift();
+
+  if (verificationDigit === undefined) {
+    return false;
+  }
+
+  const sum = reversedDigits.reduce((total, digit, index) => {
+    if (index % 2 !== 0) {
+      return total + digit;
+    }
+
+    const doubled = digit * 2;
+    return total + (doubled > 9 ? doubled - 9 : doubled);
+  }, verificationDigit);
+
+  return sum % 10 === 0;
+}

--- a/calculadora-prestamos/src/app/pages/calculator/calculator.html
+++ b/calculadora-prestamos/src/app/pages/calculator/calculator.html
@@ -73,12 +73,44 @@
 
               <div class="col-md-6">
                 <label for="documentId" class="form-label">Cédula</label>
-                <input id="documentId" name="documentId" type="text" class="form-control" placeholder="000-0000000-0"
-                  maxlength="13" inputmode="numeric" autocomplete="off" aria-describedby="documentIdHelp" required
-                  [(ngModel)]="request.documentId" (input)="formatCedulaInput()" />
+                <input
+                  id="documentId"
+                  name="documentId"
+                  type="text"
+                  class="form-control"
+                  placeholder="000-0000000-0"
+                  maxlength="13"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  aria-describedby="documentIdHelp documentIdStatus"
+                  required
+                  [class.is-valid]="showCedulaValidation && cedulaIsValid"
+                  [class.is-invalid]="showCedulaValidation && !cedulaIsValid"
+                  [attr.aria-invalid]="showCedulaValidation && !cedulaIsValid"
+                  [(ngModel)]="request.documentId"
+                  (input)="formatCedulaInput()"
+                  (blur)="markCedulaAsTouched()"
+                />
+
                 <small id="documentIdHelp" class="field-help">
                   Debe contener 11 dígitos. Ejemplo: 402-0000000-0.
                 </small>
+
+                @if (showCedulaValidation && cedulaIsValid) {
+                <div id="documentIdStatus" class="valid-feedback d-block" role="status">
+                  <i class="bi bi-check-circle-fill" aria-hidden="true"></i>
+                  Cédula válida.
+                </div>
+                } @else if (showCedulaValidation && !cedulaIsValid) {
+                <div id="documentIdStatus" class="invalid-feedback d-block" role="alert">
+                  <i class="bi bi-x-circle-fill" aria-hidden="true"></i>
+                  @if (!cedulaIsComplete) {
+                    La cédula debe contener exactamente 11 dígitos.
+                  } @else {
+                    El número no supera la validación de cédula dominicana.
+                  }
+                </div>
+                }
               </div>
             </div>
           </fieldset>

--- a/calculadora-prestamos/src/app/pages/calculator/calculator.ts
+++ b/calculadora-prestamos/src/app/pages/calculator/calculator.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { LoanCalculatorService } from '../../core/services/loan-calculator';
 import { LoanRequest } from '../../core/models/loan.model';
+import { isValidDominicanId } from '../../core/validators/dominican-id.validator';
 
 @Component({
   selector: 'app-calculator',
@@ -15,6 +16,7 @@ export class Calculator {
   private readonly loanCalculator = inject(LoanCalculatorService);
 
   errorMessage = '';
+  cedulaTouched = false;
 
   request: LoanRequest = {
     firstName: '',
@@ -29,12 +31,38 @@ export class Calculator {
 
   loanTypes = ['Personal', 'Hipotecario', 'Vehículo', 'Educativo', 'Comercial'];
 
+  get cedulaDigits(): string {
+    return this.request.documentId.replace(/\D/g, '');
+  }
+
+  get cedulaIsComplete(): boolean {
+    return this.cedulaDigits.length === 11;
+  }
+
+  get cedulaIsValid(): boolean {
+    return isValidDominicanId(this.request.documentId);
+  }
+
+  get showCedulaValidation(): boolean {
+    return this.cedulaTouched || this.cedulaIsComplete;
+  }
+
   calculate(): void {
     this.errorMessage = '';
+    this.cedulaTouched = true;
 
-    if (!this.isValidRequest()) {
-      this.errorMessage =
-        'Completa todos los campos obligatorios. La cédula debe contener 11 dígitos.';
+    if (!this.hasRequiredFields()) {
+      this.errorMessage = 'Completa todos los campos obligatorios para generar la simulación.';
+      return;
+    }
+
+    if (!this.cedulaIsComplete) {
+      this.errorMessage = 'La cédula debe contener exactamente 11 dígitos.';
+      return;
+    }
+
+    if (!this.cedulaIsValid) {
+      this.errorMessage = 'La cédula introducida no es válida. Verifica el número e inténtalo nuevamente.';
       return;
     }
 
@@ -58,20 +86,23 @@ export class Calculator {
     };
 
     this.errorMessage = '';
+    this.cedulaTouched = false;
     this.loanCalculator.clearResult();
   }
 
   formatCedulaInput(): void {
     this.request.documentId = this.formatCedula(this.request.documentId);
+    this.errorMessage = '';
   }
 
-  private isValidRequest(): boolean {
-    const cedula = this.request.documentId.replace(/\D/g, '');
+  markCedulaAsTouched(): void {
+    this.cedulaTouched = true;
+  }
 
+  private hasRequiredFields(): boolean {
     return Boolean(
       this.request.firstName.trim() &&
         this.request.lastName.trim() &&
-        cedula.length === 11 &&
         this.request.loanType &&
         this.request.amount > 0 &&
         this.request.annualRate > 0 &&


### PR DESCRIPTION
## Resumen

Incorpora validación real de cédula dominicana en LoanCalc RD, tomando como referencia la implementación pública de OGTIC en `cuenta-unica-registry`.

## Cambios

- Validador reutilizable basado en el algoritmo Luhn.
- Normalización automática de la cédula a 11 dígitos.
- Retroalimentación visual en tiempo real.
- Estados accesibles `aria-invalid`, `role="status"` y `role="alert"`.
- Bloqueo del cálculo cuando la cédula no supera el checksum.
- Mensajes diferenciados para longitud incompleta y checksum inválido.
- Documento `THIRD_PARTY_NOTICES.md` con atribución y licencia MIT de OGTIC.

## Nota técnica

La implementación original de OGTIC admite una lista privada de excepciones mediante hashes configurados por variable de entorno. LoanCalc RD incorpora el algoritmo Luhn estándar, pero no copia esa lista porque no está publicada en el repositorio.

## Validación recomendada

- Probar una cédula con 10 dígitos.
- Probar una cédula de 11 dígitos con checksum inválido.
- Probar una cédula válida.
- Ejecutar `npm run build`.